### PR TITLE
allowed collectionskimmer to have vars with multiple undescores

### DIFF
--- a/python/postprocessing/modules/bpark/collectionSkimmer.py
+++ b/python/postprocessing/modules/bpark/collectionSkimmer.py
@@ -79,7 +79,7 @@ class collectionSkimmer(Module):
 
         # add variables from other collections
         if self.importedVariables != "None":
-          cols = [ (Collection(event, (var.split("_"))[0] ), (var.split("_"))[1], i )  for i,var in enumerate(self.importedVariables) ]
+          cols = [ (Collection(event, (var.split("_"))[0] ), (var.split("_",1))[1], i )  for i,var in enumerate(self.importedVariables) ]
           for col, var, ivar in cols:
             varname = self.varnames[ivar]
             idx = self.importIds[ivar]


### PR DESCRIPTION
Allows for variables with multiple _'s in their branch name to be used in cutting on data